### PR TITLE
fix: Bump apollo dependencies to align with federation -> subgraph split

### DIFF
--- a/__tests__/__fixtures__/federatedServiceExtendingUser.ts
+++ b/__tests__/__fixtures__/federatedServiceExtendingUser.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphile-utils";
 
 import { ApolloServer } from "apollo-server";
-import { buildSubgraphSchema } from "@apollo/federation";
+import { buildSubgraphSchema } from "@apollo/subgraph";
 
 const typeDefs = gql`
   type Query {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@apollo/federation": "^0.33.0",
+        "@apollo/subgraph": "^0.1.2",
         "@graphql-tools/wrap": "^8",
         "graphile-utils": "^4.12.1",
         "graphql": "^15.6.1"
       },
       "devDependencies": {
-        "@apollo/gateway": "^0",
+        "@apollo/gateway": "^0.42.2",
         "@types/jest": "^27.0.2",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -55,11 +55,12 @@
       }
     },
     "node_modules/@apollo/federation": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.1.tgz",
-      "integrity": "sha512-BpwFw81SVfDb1HpH7MYLiqsPvAcXRKiIJoXD5pULBvLV3dxgB9WT3dJoXeMyAemVBpTQtPqSky9B2M8l2NH+uA==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.2.tgz",
+      "integrity": "sha512-UwzLHPFXQfFPvHRugPcxVaXeWlFM3MQnkB+KmepT10VzErJPGsfFJ9dAnLSy2xlWysmI0AN95J8oLo+6fmkunA==",
+      "dev": true,
       "dependencies": {
-        "@apollo/subgraph": "^0.1.0",
+        "@apollo/subgraph": "^0.1.1",
         "apollo-graphql": "^0.9.3",
         "apollo-server-types": "^3.0.2",
         "lodash.xorby": "^4.7.0"
@@ -72,13 +73,13 @@
       }
     },
     "node_modules/@apollo/gateway": {
-      "version": "0.42.1",
-      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.42.1.tgz",
-      "integrity": "sha512-ve5lr9r/1F+wqFmPrajE4YM8HEFKMAbsZk/n+WFyJO5nctcYiZ8456OitihA7jIvYvUIwvURCjkOcbx1Q0mVZw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.42.2.tgz",
+      "integrity": "sha512-D95i426mzO0BKPKdWWLOHJ/41aCX+B0J4CZ15r3Jqo7uWP1or1hz6k1wmcwwxWVzAa56fE9yjOqawBLhSpcKNw==",
       "dev": true,
       "dependencies": {
         "@apollo/core-schema": "^0.1.0",
-        "@apollo/federation": "^0.33.1",
+        "@apollo/federation": "^0.33.2",
         "@apollo/query-planner": "^0.5.1",
         "@opentelemetry/api": "^1.0.1",
         "@types/node-fetch": "2.5.12",
@@ -104,6 +105,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
       "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -128,7 +130,8 @@
     "node_modules/@apollo/protobufjs/node_modules/@types/node": {
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true
     },
     "node_modules/@apollo/query-planner": {
       "version": "0.5.1",
@@ -149,9 +152,9 @@
       }
     },
     "node_modules/@apollo/subgraph": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.0.tgz",
-      "integrity": "sha512-R4xwPd4YC/Dntg02AHH1VsWDrNJrJjWl0MNEOK5gHCH26IJEUuuqy0ohsaMev0UhmYLI2pNA8w0tbJa5knxGgw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.2.tgz",
+      "integrity": "sha512-vrPtpayvJkLdqc/iLjhXi+W9HQ+Avnb2a8ylaZb0lsm9p0y1H5QxNDhC3SHhdYRvBnNeqgxE+OGYG1rHldMQIQ==",
       "dependencies": {
         "apollo-graphql": "^0.9.3"
       },
@@ -1363,27 +1366,32 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1392,27 +1400,32 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -1633,7 +1646,8 @@
     "node_modules/@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -2110,6 +2124,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.0.0.tgz",
       "integrity": "sha512-jmCD+6gECt8KS7PxP460hztT/5URTbv2Kg0zgnR6iWPGce88IBmSUjcqf1Z6wJJq7Teb8Hu7WbyyMhn0vN5TxQ==",
+      "dev": true,
       "dependencies": {
         "@apollo/protobufjs": "1.2.2"
       }
@@ -2132,6 +2147,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.1.0.tgz",
       "integrity": "sha512-bZ4bo0kSAsax9LbMQPlpuMTkQ657idF2ehOYe4Iw+8vj7vfAYa39Ii9IlaVAFMC1FxCYzLNFz+leZBm/Stn/NA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2178,6 +2194,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.0.3.tgz",
       "integrity": "sha512-B32+RUOM4GUJAwnQqQE1mT1BG7+VfW3a0A87Bp3gv/q8iNnhY2BIWe74Qn03pX8n27g3EGVCt0kcBuHhjG5ltA==",
+      "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.1"
       },
@@ -2242,6 +2259,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.2.0.tgz",
       "integrity": "sha512-Fh7QP84ufDZHbLzoLyyxyzznlW8cpgEZYYkGsS1i36zY4VaAt5OUOp1f+FxWdLGehq0Arwb6D1W7y712IoZ/JQ==",
+      "dev": true,
       "dependencies": {
         "apollo-reporting-protobuf": "^3.0.0",
         "apollo-server-caching": "^3.1.0",
@@ -6535,7 +6553,8 @@
     "node_modules/lodash.xorby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
-      "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c="
+      "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c=",
+      "dev": true
     },
     "node_modules/loglevel": {
       "version": "1.7.1",
@@ -6553,12 +6572,14 @@
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6878,6 +6899,7 @@
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
       "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6888,17 +6910,20 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -9058,7 +9083,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -9097,24 +9123,25 @@
       "requires": {}
     },
     "@apollo/federation": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.1.tgz",
-      "integrity": "sha512-BpwFw81SVfDb1HpH7MYLiqsPvAcXRKiIJoXD5pULBvLV3dxgB9WT3dJoXeMyAemVBpTQtPqSky9B2M8l2NH+uA==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.2.tgz",
+      "integrity": "sha512-UwzLHPFXQfFPvHRugPcxVaXeWlFM3MQnkB+KmepT10VzErJPGsfFJ9dAnLSy2xlWysmI0AN95J8oLo+6fmkunA==",
+      "dev": true,
       "requires": {
-        "@apollo/subgraph": "^0.1.0",
+        "@apollo/subgraph": "^0.1.1",
         "apollo-graphql": "^0.9.3",
         "apollo-server-types": "^3.0.2",
         "lodash.xorby": "^4.7.0"
       }
     },
     "@apollo/gateway": {
-      "version": "0.42.1",
-      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.42.1.tgz",
-      "integrity": "sha512-ve5lr9r/1F+wqFmPrajE4YM8HEFKMAbsZk/n+WFyJO5nctcYiZ8456OitihA7jIvYvUIwvURCjkOcbx1Q0mVZw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.42.2.tgz",
+      "integrity": "sha512-D95i426mzO0BKPKdWWLOHJ/41aCX+B0J4CZ15r3Jqo7uWP1or1hz6k1wmcwwxWVzAa56fE9yjOqawBLhSpcKNw==",
       "dev": true,
       "requires": {
         "@apollo/core-schema": "^0.1.0",
-        "@apollo/federation": "^0.33.1",
+        "@apollo/federation": "^0.33.2",
         "@apollo/query-planner": "^0.5.1",
         "@opentelemetry/api": "^1.0.1",
         "@types/node-fetch": "2.5.12",
@@ -9134,6 +9161,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
       "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9153,7 +9181,8 @@
         "@types/node": {
           "version": "10.17.60",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+          "dev": true
         }
       }
     },
@@ -9170,9 +9199,9 @@
       }
     },
     "@apollo/subgraph": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.0.tgz",
-      "integrity": "sha512-R4xwPd4YC/Dntg02AHH1VsWDrNJrJjWl0MNEOK5gHCH26IJEUuuqy0ohsaMev0UhmYLI2pNA8w0tbJa5knxGgw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.2.tgz",
+      "integrity": "sha512-vrPtpayvJkLdqc/iLjhXi+W9HQ+Avnb2a8ylaZb0lsm9p0y1H5QxNDhC3SHhdYRvBnNeqgxE+OGYG1rHldMQIQ==",
       "requires": {
         "apollo-graphql": "^0.9.3"
       }
@@ -10117,27 +10146,32 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -10146,27 +10180,32 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -10377,7 +10416,8 @@
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -10718,6 +10758,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.0.0.tgz",
       "integrity": "sha512-jmCD+6gECt8KS7PxP460hztT/5URTbv2Kg0zgnR6iWPGce88IBmSUjcqf1Z6wJJq7Teb8Hu7WbyyMhn0vN5TxQ==",
+      "dev": true,
       "requires": {
         "@apollo/protobufjs": "1.2.2"
       }
@@ -10737,6 +10778,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.1.0.tgz",
       "integrity": "sha512-bZ4bo0kSAsax9LbMQPlpuMTkQ657idF2ehOYe4Iw+8vj7vfAYa39Ii9IlaVAFMC1FxCYzLNFz+leZBm/Stn/NA==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -10774,6 +10816,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.0.3.tgz",
       "integrity": "sha512-B32+RUOM4GUJAwnQqQE1mT1BG7+VfW3a0A87Bp3gv/q8iNnhY2BIWe74Qn03pX8n27g3EGVCt0kcBuHhjG5ltA==",
+      "dev": true,
       "requires": {
         "node-fetch": "^2.6.1"
       }
@@ -10817,6 +10860,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.2.0.tgz",
       "integrity": "sha512-Fh7QP84ufDZHbLzoLyyxyzznlW8cpgEZYYkGsS1i36zY4VaAt5OUOp1f+FxWdLGehq0Arwb6D1W7y712IoZ/JQ==",
+      "dev": true,
       "requires": {
         "apollo-reporting-protobuf": "^3.0.0",
         "apollo-server-caching": "^3.1.0",
@@ -14108,7 +14152,8 @@
     "lodash.xorby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
-      "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c="
+      "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c=",
+      "dev": true
     },
     "loglevel": {
       "version": "1.7.1",
@@ -14119,12 +14164,14 @@
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -14366,6 +14413,7 @@
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
       "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -14373,17 +14421,20 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -15999,7 +16050,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
   },
   "homepage": "https://github.com/mgagliardo91/postgraphile-federation-plugin#readme",
   "dependencies": {
-    "@apollo/federation": "^0.33.0",
+    "@apollo/subgraph": "^0.1.2",
     "@graphql-tools/wrap": "^8",
     "graphile-utils": "^4.12.1",
     "graphql": "^15.6.1"
   },
   "devDependencies": {
-    "@apollo/gateway": "^0",
+    "@apollo/gateway": "^0.42.2",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,17 +25,6 @@ export type GraphQLReferenceResolver<TContext> = (
   info: GraphQLResolveInfo,
 ) => unknown;
 
-declare module "graphql/type/definition" {
-  interface GraphQLObjectType {
-    resolveReference?: GraphQLReferenceResolver<unknown>;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface GraphQLObjectTypeConfig<TSource, TContext> {
-    resolveReference?: GraphQLReferenceResolver<TContext>;
-  }
-}
-
 /**
  * This plugin installs the schema outlined in the Apollo Federation spec, and
  * the resolvers and types required. Comments have been added to make things

--- a/src/printFederatedSchema.ts
+++ b/src/printFederatedSchema.ts
@@ -1,4 +1,4 @@
-import { printSchema } from "@apollo/federation";
+import { printSubgraphSchema } from "@apollo/subgraph";
 import { FilterTypes, TransformRootFields, wrapSchema } from "@graphql-tools/wrap";
 import { GraphQLSchema } from "graphql";
 
@@ -16,7 +16,7 @@ let lastPrint: string;
 /**
  * When we print the federated schema we need to transform it to remove the
  * Apollo Federation fields (whilst keeping the directives). We need to use the
- * special `printSchema` function from the `@apollo/federation` package because
+ * special `printSubgraphSchema` function from the `@apollo/subgraph` package because
  * GraphQL's `printSchema` does not include directives.
  *
  * We've added simple memoization for performance reasons; better memoization
@@ -56,7 +56,7 @@ export default function printFederatedSchema(schema: GraphQLSchema): string {
     });
 
     // Print the schema, including the federation directives.
-    lastPrint = printSchema(schemaSansFederationFields);
+    lastPrint = printSubgraphSchema(schemaSansFederationFields);
   }
   return lastPrint;
 }


### PR DESCRIPTION
Replaces the `@apollo/federation` package with `@apollo/subgraph`.