### PR TITLE
fix: Broken dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@apollo/subgraph": "^0.3.1",
         "@graphql-tools/wrap": "^8",
-        "graphile-utils": "^4.12.1",
-        "graphql": "^16.3.0"
+        "graphile-utils": "^4.12.2",
+        "graphql": "^15.8.0"
       },
       "devDependencies": {
         "@apollo/gateway": "^0.48.1",
@@ -5066,20 +5066,12 @@
         "graphile-build-pg": "^4.5.0"
       }
     },
-    "node_modules/graphile-utils/node_modules/graphql": {
+    "node_modules/graphql": {
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
       }
     },
     "node_modules/graphql-executor": {
@@ -7682,15 +7674,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/postgraphile/node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.x"
       }
     },
     "node_modules/postgraphile/node_modules/has-flag": {
@@ -13232,19 +13215,12 @@
         "debug": "^4.1.1",
         "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0",
         "tslib": "^2.0.1"
-      },
-      "dependencies": {
-        "graphql": {
-          "version": "15.8.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-          "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
-        }
       }
     },
     "graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A=="
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
     },
     "graphql-executor": {
       "version": "0.0.18",
@@ -15198,12 +15174,6 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "graphql": {
-          "version": "15.8.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-          "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
           "dev": true
         },
         "has-flag": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "dependencies": {
     "@apollo/subgraph": "^0.3.1",
     "@graphql-tools/wrap": "^8",
-    "graphile-utils": "^4.12.1",
-    "graphql": "^16.3.0"
+    "graphile-utils": "^4.12.2",
+    "graphql": "^15.8.0"
   },
   "devDependencies": {
     "@apollo/gateway": "^0.48.1",
@@ -60,6 +60,9 @@
     "prettier": "^2.4.1",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.3"
+  },
+  "resolutions": {
+    "graphql": "^16.3.0"
   },
   "peerDependencies": {
     "graphile-build": "^4.12.0",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.3"
   },
-  "resolutions": {
-    "graphql": "^16.3.0"
-  },
   "peerDependencies": {
     "graphile-build": "^4.12.0",
     "graphile-build-pg": "^4.12.1"

--- a/src/AST.ts
+++ b/src/AST.ts
@@ -10,6 +10,10 @@ import type {
   StringValueNode,
 } from "graphql";
 
+import {
+  Kind
+} from "graphql"
+
 /**
  * Construct AST `name` node required for Apollo Federation's printSchema.
  * @param value The value.
@@ -17,7 +21,7 @@ import type {
  */
 export function Name(value: string): NameNode {
   return {
-    kind: "Name",
+    kind: Kind.NAME,
     value,
   };
 }
@@ -30,7 +34,7 @@ export function Name(value: string): NameNode {
  */
 export function StringValue(value: string, block = false): StringValueNode {
   return {
-    kind: "StringValue",
+    kind: Kind.STRING,
     value,
     block: block,
   };
@@ -46,7 +50,7 @@ export function ObjectTypeDefinition(spec: {
   description?: string | null;
 }): ObjectTypeDefinitionNode {
   return {
-    kind: "ObjectTypeDefinition",
+    kind: Kind.OBJECT_TYPE_DEFINITION,
     name: Name(spec.name),
     description: spec.description
       ? StringValue(spec.description, true)
@@ -66,7 +70,7 @@ export function Directive(
   args: { [argName: string]: unknown } = {},
 ): DirectiveNode {
   return {
-    kind: "Directive",
+    kind: Kind.DIRECTIVE,
     name: Name(name),
     arguments: Object.entries(args).map(
       ([argName, value]) =>


### PR DESCRIPTION
It was pointed out via @trevor-scheer in [Issue 122](https://github.com/mgagliardo91/postgraphile-federation-plugin/issues/122) that dependencies were being merged even after broken CI jobs. Unfortunately, this was a result of missing branch protections on the main branch.

This PR resets the failing dependency (bumping to GraphQL v16) since postgraphile does not currently support it: https://github.com/graphile/graphile-engine/pull/764

I have also added branch protections to ensure a successful CI pipeline before dependabot PRs are allowed to be auto-merged.

Thanks @trevor-scheer 🙏 